### PR TITLE
chore: test monorepo structure on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
     steps:
       - name: Setup repo
         uses: actions/checkout@v2


### PR DESCRIPTION
### Linked issue
This enables Windows to test the monorepo structure. Mostly used to validate if `expo-yarn-workspaces` behaves as expected on Windows.
