### PR TITLE
chore: test yarn workspaces without fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,13 @@ jobs:
     name: Build and test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        node: [12, 14]
+        node: [10, 12, 14]
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
     steps:
       - name: Setup repo
         uses: actions/checkout@v2


### PR DESCRIPTION
### Linked issue
To demonstrate the symlink issue with `expo-yarn-workspaces` on Windows.
