### PR TITLE
fix: allow windows end of lines on windows

### DIFF
--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -1,4 +1,7 @@
 module.exports = {
   extends: 'eslint-config-universe',
   // do some additional things with it
+  rules: {
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
+  },
 };


### PR DESCRIPTION
### Linked issue
This should remove the EOL annotations for windows tests.
