### PR TITLE
chore: fix Readme badges issue, tweak spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <div align="center">
   <h1>EAS monorepo example</h1>
-  <p></p>
   <p>Enterprise-ready Expo Application Service monorepo with code sharing</p>
-  <sup>
+  <p>
     <a href="https://github.com/byCedric/eas-monorepo-example/releases">
       <img src="https://img.shields.io/github/workflow/status/byCedric/eas-monorepo-example/preview?style=flat-square" alt="managed preview" />
     </a>
@@ -12,20 +11,18 @@
     <a href="https://github.com/byCedric/eas-monorepo-example/blob/main/LICENSE.md">
       <img src="https://img.shields.io/github/license/byCedric/eas-monorepo-example?style=flat-square" alt="license" />
     </a>
-  </sup>
-  <br />
-  <p align="center">
+  </p>
+  <p>
     <a href="https://github.com/byCedric/eas-monorepo-example#-structure"><b>Structure</b></a>
-    &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+    &ensp;&mdash;&ensp;
     <a href="https://github.com/byCedric/eas-monorepo-example#-workflows"><b>Workflows</b></a>
-    &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+    &ensp;&mdash;&ensp;
     <a href="https://github.com/byCedric/eas-monorepo-example#-how-to-use-it"><b>How to use it</b></a>
-    &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+    &ensp;&mdash;&ensp;
     <a href="https://github.com/byCedric/eas-monorepo-example#%EF%B8%8F-caveats"><b>Caveats</b></a>
-    &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+    &ensp;&mdash;&ensp;
     <a href="https://github.com/byCedric/eas-monorepo-example#-common-errors"><b>Common Errors</b></a>
   </p>
-  <br />
 </div>
 
 ## 📁 Structure


### PR DESCRIPTION
### Linked issue

Currently the badges in repository Readme have an additional brackets around images:
<img width="815" alt="Screenshot 2021-09-17 143751" src="https://user-images.githubusercontent.com/719641/133783699-f7f73c08-9b0f-4cee-a979-638963d44c9b.png">

### Additional context

I have also tweaked the spacing a bit in this PR by simplifying the HTML, but the goal was to stay as close to the original presentation as possible. 🙂 

### Preview

<img width="800" alt="Screenshot 2021-09-17 143531" src="https://user-images.githubusercontent.com/719641/133783987-368f3269-16f2-49a1-8c97-aaf098b16654.png">

