### PR TITLE
fix(apps/with-dev-client): pin mmkv version and use proper path in plugin

### DIFF
--- a/apps/with-dev-client/App.tsx
+++ b/apps/with-dev-client/App.tsx
@@ -2,14 +2,15 @@ import { Paragraph, Strong } from "@acme/ui";
 import { StatusBar } from "expo-status-bar";
 import React, { useState } from "react";
 import { Button, StyleSheet, TextInput, View } from "react-native";
-import { MMKV, useMMKVString } from "react-native-mmkv";
+import { MMKV } from "react-native-mmkv";
+
+import { useMmkvString } from "./hooks";
 
 const storage = new MMKV();
 
 export default function App() {
   const [usernameInput, setUsernameInput] = useState("");
-
-  const [username, setUsername] = useMMKVString("user.name", storage);
+  const [username, saveUsername] = useMmkvString("user.name", storage);
 
   return (
     <View style={styles.container}>
@@ -27,7 +28,7 @@ export default function App() {
       />
       <Button
         title="Save"
-        onPress={() => usernameInput.length && setUsername(usernameInput)}
+        onPress={() => saveUsername(usernameInput || undefined)}
       />
       <StatusBar style="auto" />
     </View>

--- a/apps/with-dev-client/hooks.ts
+++ b/apps/with-dev-client/hooks.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from "react";
+import { MMKV } from "react-native-mmkv";
+
+type MmkvString = ReturnType<MMKV["getString"]>;
+type MmkvStringSetter = (value?: string) => void;
+
+/**
+ * Fetch a value from storage and keep track of it while interacting.
+ * Note, this does not update when the value is changed without the setter.
+ * This version (1.3.1) of MMKV does not have the value listener.
+ */
+export function useMmkvString(
+  name: string,
+  storage: MMKV
+): [MmkvString, MmkvStringSetter] {
+  const [value, setValue] = useState<MmkvString>(() => storage.getString(name));
+
+  const setCallback = useCallback<MmkvStringSetter>(
+    (newValue) => {
+      if (newValue === undefined) {
+        storage.delete(name);
+        setValue(undefined);
+      } else {
+        storage.set(name, newValue);
+        setValue(newValue);
+      }
+    },
+    [name, storage]
+  );
+
+  return [value, setCallback];
+}

--- a/apps/with-dev-client/index.js
+++ b/apps/with-dev-client/index.js
@@ -1,5 +1,3 @@
-import 'expo-dev-client';
-
 import "expo-dev-client";
 
 import { registerRootComponent } from "expo";

--- a/apps/with-dev-client/index.js
+++ b/apps/with-dev-client/index.js
@@ -1,3 +1,5 @@
+import 'expo-dev-client';
+
 import "expo-dev-client";
 
 import { registerRootComponent } from "expo";

--- a/apps/with-dev-client/package.json
+++ b/apps/with-dev-client/package.json
@@ -24,7 +24,7 @@
     "react-dom": "17.0.1",
     "react-native": "0.64.2",
     "react-native-gesture-handler": "~1.10.2",
-    "react-native-mmkv": "^1.5.2",
+    "react-native-mmkv": "1.3.2",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.8.0",

--- a/apps/with-dev-client/react-native-mmkv-plugin.js
+++ b/apps/with-dev-client/react-native-mmkv-plugin.js
@@ -153,7 +153,7 @@ const withCustomSettingsGradle = (config) => {
       config.modResults.contents +
       `
 include ':react-native-mmkv'
-project(':react-native-mmkv').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-mmkv/android/')
+project(':react-native-mmkv').projectDir = new File(["node", "--print", "require.resolve('react-native-mmkv/package.json')"].execute().text.trim(), "../android")
 `;
     return config;
   });
@@ -178,7 +178,7 @@ const withCustomAppBuildGradle = (config) => {
   });
 };
 
-module.exports = function withMMKV(config, name) {
+module.exports = function withMMKV(config) {
   config = withMMKVJSIModulePackage(config);
   config = withMainApplication(config);
   config = withCustomSettingsGradle(config);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7666,10 +7666,10 @@ react-native-gesture-handler@~1.10.2:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-mmkv@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-1.5.2.tgz#d2b84f22f13d3ed0c2395addbd6ef8f2fe986c35"
-  integrity sha512-vvmtcjWVUTKoErg1RxMwPijyoySqWd2nuD6LC1PiZsBQO0sCXi8mJel1dI5Agnq3SsNYhPTcRNSHzVKz4q7gyw==
+react-native-mmkv@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-1.3.2.tgz#fb5a3f4f369076c50fa07338c6f24ad02c9342ba"
+  integrity sha512-A1ztKk3YJobuq9LAS3o7LJnxqw8yUKwACRsoVXUYPWw0RbwjmE10Ogdz8axrSIGHd6gjKeIrLgS5eetcj27pCA==
 
 react-native-reanimated@~2.2.0:
   version "2.2.0"


### PR DESCRIPTION
### Linked issue
Fixes #27 

### Additional context
It seems like there are some unfortunate changes, including:

- Breaking backward compatibility for React Native <0.66 ([this comment](https://github.com/mrousavy/react-native-mmkv/issues/145#issuecomment-939482112) and [this issue](https://github.com/mrousavy/react-native-mmkv/issues/177))
- Multiple monorepo fixes, but they all seem to have issues with hoisting (see [this list of prs](https://github.com/mrousavy/react-native-mmkv/pulls?q=monorepo))

We probably want to pull this out from the repo and back into a PR. Only if it's stable we should add it.
