### PR TITLE
fix(apps/ejected): upgrade gesture handler to fix monorepo usage

### DIFF
--- a/apps/ejected/package.json
+++ b/apps/ejected/package.json
@@ -23,7 +23,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-native": "0.64.3",
-    "react-native-gesture-handler": "~2.1.0",
+    "react-native-gesture-handler": "~2.2.0",
     "react-native-reanimated": "~2.3.1",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7682,6 +7682,17 @@ react-native-gesture-handler@~2.1.0:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
+react-native-gesture-handler@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.2.0.tgz#a551f9ca33d8766d0a24268f49e0f1b05191b105"
+  integrity sha512-WF25CNgn164bF9juW8N/jICIFXiEOgsxCuY7DRlnFdiH5ZfvMYtZHRC+zr1fFMap2ty1f2HWDQNVVSo0FDXP4A==
+  dependencies:
+    "@egjs/hammerjs" "^2.0.17"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
+
 react-native-mmkv@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-1.3.2.tgz#fb5a3f4f369076c50fa07338c6f24ad02c9342ba"


### PR DESCRIPTION
### Linked issue
https://github.com/software-mansion/react-native-gesture-handler/issues/1772