### PR TITLE
fix: add missing `disableHierarchicalLookup` to metro

### DIFF
--- a/apps/ejected/metro.config.js
+++ b/apps/ejected/metro.config.js
@@ -8,6 +8,7 @@ const workspaceRoot = path.resolve(projectRoot, '../..');
 const config = getDefaultConfig(projectRoot);
 
 config.watchFolders = [workspaceRoot];
+config.resolver.disableHierarchicalLookup = true;
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),

--- a/apps/managed/metro.config.js
+++ b/apps/managed/metro.config.js
@@ -8,6 +8,7 @@ const workspaceRoot = path.resolve(projectRoot, '../..');
 const config = getDefaultConfig(projectRoot);
 
 config.watchFolders = [workspaceRoot];
+config.resolver.disableHierarchicalLookup = true;
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),

--- a/apps/with-dev-client/metro.config.js
+++ b/apps/with-dev-client/metro.config.js
@@ -8,6 +8,7 @@ const workspaceRoot = path.resolve(projectRoot, '../..');
 const config = getDefaultConfig(projectRoot);
 
 config.watchFolders = [workspaceRoot];
+config.resolver.disableHierarchicalLookup = true;
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),

--- a/apps/with-sentry/metro.config.js
+++ b/apps/with-sentry/metro.config.js
@@ -8,6 +8,7 @@ const workspaceRoot = path.resolve(projectRoot, '../..');
 const config = getDefaultConfig(projectRoot);
 
 config.watchFolders = [workspaceRoot];
+config.resolver.disableHierarchicalLookup = true;
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),


### PR DESCRIPTION
### Linked issue
This property is required to force-resolve all libraries from the `nodeModulesPaths`.

### Additional context
See https://github.com/expo/expo/pull/18756